### PR TITLE
fix: update dynamodb record instead of putting a new record

### DIFF
--- a/cdk/BackendStack.ts
+++ b/cdk/BackendStack.ts
@@ -68,10 +68,6 @@ export class BackendStack extends Stack {
 				name: 'iccid',
 				type: DynamoDB.AttributeType.STRING,
 			},
-			sortKey: {
-				name: 'timestamp',
-				type: DynamoDB.AttributeType.STRING,
-			},
 			removalPolicy: isTest
 				? CloudFormation.RemovalPolicy.DESTROY
 				: CloudFormation.RemovalPolicy.RETAIN,

--- a/e2e-tests/seedingDBFunction.ts
+++ b/e2e-tests/seedingDBFunction.ts
@@ -22,6 +22,10 @@ export const seedingDBFunction = async ({
 		usedBytes: 50,
 		totalBytes: 1000,
 	}
+	const simDetails3 = {
+		usedBytes: 25,
+		totalBytes: 1000,
+	}
 	//put recent data on DB
 	await putSimDetails(db, outputs.cacheTableName)(
 		iccidNew,
@@ -29,7 +33,14 @@ export const seedingDBFunction = async ({
 		simDetails,
 		now,
 	)
-	//put old data in DB
+	//put 10 min old data in DB for iccidOld
+	await putSimDetails(db, outputs.cacheTableName)(
+		iccidOld,
+		true,
+		simDetails3,
+		new Date(Date.now() - 10 * 60 * 1000),
+	)
+	//put 6 min old data in DB for iccidOld
 	await putSimDetails(db, outputs.cacheTableName)(
 		iccidOld,
 		true,


### PR DESCRIPTION
by removing the sort key (timestamp) we only use the partitionKey as a primary key and every record with the same partitionkey (iccid) will be updated