### PR TITLE
fix: schedule lambda at midnight

### DIFF
--- a/cdk/BackendStack.ts
+++ b/cdk/BackendStack.ts
@@ -291,7 +291,7 @@ export class BackendStack extends Stack {
 		)
 		simDetailsCacheTable.grantReadWriteData(dailyOnomondoUpdate.fn)
 		const dailyRule = new Events.Rule(this, 'InvokeActivitiesDailyRule', {
-			schedule: Events.Schedule.expression('rate(1 day)'),
+			schedule: Events.Schedule.expression('cron(0 0 * * ? *)'),
 			description: `Invoke the lambdas that fetches usage for all active SIMs`,
 			enabled: true,
 			targets: [new EventsTargets.LambdaFunction(dailyOnomondoUpdate.fn)],


### PR DESCRIPTION
This lambda is used to make sure we get the history from the last hour before midnight, and it should be called at midnight. With a daily schedule it will be called sometime during the day, but I want it to get called at midnight to make sure we get the data as early as possible. 