### PR TITLE
fix: return empty body if SIM not in vendor API

### DIFF
--- a/e2e-tests/getSIMDetailsSIMMissingFromVendorAPI.spec.ts
+++ b/e2e-tests/getSIMDetailsSIMMissingFromVendorAPI.spec.ts
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict'
+import { it } from 'node:test'
+import { clients } from './lib/clients.ts'
+import { getRandomICCID } from './lib/getRandomICCID.ts'
+
+const { seedDB, fetch } = await clients()
+
+/*
+This can happen when users claim their SIM and we no longer have access to the data coming from the SIM in the vendor API. 
+*/
+void it(`should return statusCode 200, cache max-age=60 and an empty body for SIM that is missing from vendor API`, async () => {
+	const now = new Date()
+	const iccid = getRandomICCID(4446)
+	await seedDB({
+		iccid,
+		usageTimestamp: now,
+		simDetails: { usedBytes: 0, totalBytes: 0 },
+		simExisting: true,
+		SIMMissingFromVendorAPI: true,
+	})
+
+	const res = await fetch(iccid)
+	const expectedCacheControl = 'public, max-age=60'
+	assert.equal(res.headers.get('cache-control'), expectedCacheControl)
+	assert.equal(res.status, 200)
+	assert.equal(res.headers.get('content-length'), '0')
+	assert.equal(await res.text(), '')
+})

--- a/e2e-tests/lib/seedDynamoDB.ts
+++ b/e2e-tests/lib/seedDynamoDB.ts
@@ -9,11 +9,13 @@ export const seedDynamoDB =
 		usageTimestamp,
 		simDetails,
 		simExisting,
+		SIMMissingFromVendorAPI,
 	}: {
 		iccid: string
 		usageTimestamp: Date
 		simDetails: { usedBytes: number; totalBytes: number }
 		simExisting?: boolean
+		SIMMissingFromVendorAPI?: boolean
 	}): Promise<void> => {
 		await putSimDetails(
 			db,
@@ -21,6 +23,7 @@ export const seedDynamoDB =
 		)({
 			iccid,
 			simExisting: simExisting ?? true,
+			SIMMissingFromVendorAPI: SIMMissingFromVendorAPI ?? false,
 			simDetails,
 			ts: usageTimestamp,
 		})

--- a/lambda/getAllSimUsageWirelessLogic.ts
+++ b/lambda/getAllSimUsageWirelessLogic.ts
@@ -82,7 +82,12 @@ const h = async (): Promise<void> => {
 					usedBytes: usage.value.usedBytes[iccid] ?? 0,
 					totalBytes: usage.value.totalBytes,
 				}
-				await putSimDetailsFunc({ iccid, simExisting: true, simDetails })
+				await putSimDetailsFunc({
+					iccid,
+					simExisting: true,
+					simDetails,
+					SIMMissingFromVendorAPI: false,
+				})
 			}
 		}),
 	)

--- a/lambda/getBasicInformationLambda.ts
+++ b/lambda/getBasicInformationLambda.ts
@@ -16,6 +16,7 @@ import { res } from '../api/res.ts'
 import { onomondoIIN, wirelessLogicIIN } from './constants.ts'
 import { getAvailableColumns } from './getAvailableColumns.ts'
 import {
+	SIMMissingFromVendorAPI,
 	SIMNotFoundError,
 	getSimDetailsFromCache,
 } from './getSimDetailsFromCache.ts'
@@ -118,6 +119,10 @@ const h = async (
 			})({ payload: { iccid }, deduplicationId: iccid })
 			track('api:noSIMInfoCache', MetricUnit.Count, 1)
 			return res(toStatusCode[ErrorType.Conflict], { expires: 60 })()
+		}
+		if (maybeSimDetails.error instanceof SIMMissingFromVendorAPI) {
+			track('api:SIMMissingFromVendorAPI', MetricUnit.Count, 1)
+			return res(200, { expires: 60 })()
 		}
 		track('api:SIMNotExisting', MetricUnit.Count, 1)
 		//SIM not existing

--- a/lambda/getSimDetailsFromCache.spec.ts
+++ b/lambda/getSimDetailsFromCache.spec.ts
@@ -2,6 +2,7 @@ import type { DynamoDBClient } from '@aws-sdk/client-dynamodb'
 import assert from 'node:assert/strict'
 import { describe, it, mock } from 'node:test'
 import {
+	SIMMissingFromVendorAPI,
 	SIMNotExistingError,
 	SIMNotFoundError,
 	getSimDetailsFromCache,
@@ -46,6 +47,31 @@ void describe('getSimDetailsFromCache()', () => {
 		const simDetails = await getSimDetailsFromCache(db, cacheTableName)(iccid)
 		assert.equal(
 			'error' in simDetails && simDetails.error instanceof SIMNotExistingError,
+			true,
+		)
+	})
+	void it('should return SIMMissingFromVendorAPI if SIM is not existing', async () => {
+		const cacheTableName = 'cacheTable'
+		const iccid = '1234567890'
+		const dynamoDbSend = mock.fn(async () =>
+			Promise.resolve({
+				Items: [
+					{
+						SIMMissingFromVendorAPI: { B: true },
+						ts: { N: 1719219232398 },
+						usedBytes: { N: 0 },
+						totalBytes: { N: 0 },
+					},
+				],
+			}),
+		)
+		const db: DynamoDBClient = {
+			send: dynamoDbSend,
+		} as any
+		const simDetails = await getSimDetailsFromCache(db, cacheTableName)(iccid)
+		assert.equal(
+			'error' in simDetails &&
+				simDetails.error instanceof SIMMissingFromVendorAPI,
 			true,
 		)
 	})

--- a/lambda/getSimDetailsFromCache.ts
+++ b/lambda/getSimDetailsFromCache.ts
@@ -12,7 +12,7 @@ export const getSimDetailsFromCache =
 		iccid: string,
 	): Promise<
 		| {
-				error: SIMNotFoundError | SIMNotExistingError
+				error: SIMNotFoundError | SIMNotExistingError | SIMMissingFromVendorAPI
 		  }
 		| {
 				sim: SimDetails & {
@@ -31,7 +31,7 @@ export const getSimDetailsFromCache =
 					},
 				},
 				ProjectionExpression:
-					'usedBytes, totalBytes, SIMExisting, ts, historyTs',
+					'usedBytes, totalBytes, SIMExisting, SIMMissingFromVendorAPI, ts, historyTs',
 				Limit: 1,
 			}),
 		)
@@ -40,7 +40,9 @@ export const getSimDetailsFromCache =
 		if (sim === undefined) {
 			return { error: new SIMNotFoundError(iccid) }
 		}
-
+		if (sim.SIMMissingFromVendorAPI === true) {
+			return { error: new SIMMissingFromVendorAPI(iccid) }
+		}
 		//SIM is not existing
 		if (sim.SIMExisting === false) {
 			return { error: new SIMNotExistingError(iccid) }
@@ -84,5 +86,13 @@ export class SIMNotExistingError extends Error {
 		super(`SIM not existing: ${iccid}`)
 		this.iccid = iccid
 		this.name = 'SIMNotExistingError'
+	}
+}
+export class SIMMissingFromVendorAPI extends Error {
+	public readonly iccid: string
+	constructor(iccid: string) {
+		super(`SIM data missing in vendor API: ${iccid}`)
+		this.iccid = iccid
+		this.name = 'SIMMissingFromVendorAPI'
 	}
 }

--- a/lambda/putSimDetails.ts
+++ b/lambda/putSimDetails.ts
@@ -6,15 +6,19 @@ export const putSimDetails =
 	async ({
 		iccid,
 		simExisting,
+		SIMMissingFromVendorAPI,
 		simDetails,
 		historyTs,
 		ts,
+		ttl,
 	}: {
 		iccid: string
 		simExisting: boolean
+		SIMMissingFromVendorAPI: boolean
 		simDetails?: SimDetails
 		historyTs?: Date
 		ts?: Date
+		ttl?: number
 	}): Promise<void> => {
 		await db.send(
 			new PutItemCommand({
@@ -22,10 +26,11 @@ export const putSimDetails =
 				Item: marshall({
 					iccid,
 					historyTs: historyTs ? historyTs.toISOString() : null,
-					ttl: Date.now() / 1000 + 24 * 60 * 60 * 30, // 30 days
+					ttl: ttl ?? Date.now() / 1000 + 24 * 60 * 60 * 30, // 30 days
 					usedBytes: simDetails?.usedBytes ?? 0,
 					totalBytes: simDetails?.totalBytes ?? 0,
 					SIMExisting: simExisting,
+					SIMMissingFromVendorAPI,
 					ts: (ts ?? new Date()).toISOString(),
 				}),
 			}),

--- a/lambda/storeSimInformationOnomondo.ts
+++ b/lambda/storeSimInformationOnomondo.ts
@@ -71,6 +71,7 @@ const h = async (event: SQSEvent): Promise<void> => {
 					iccid,
 					simExisting: false,
 					simDetails: undefined,
+					SIMMissingFromVendorAPI: false,
 				})
 			} else {
 				let historyTsForStoring = historyTs
@@ -134,6 +135,7 @@ const h = async (event: SQSEvent): Promise<void> => {
 					simExisting: true,
 					simDetails: simDetails.value,
 					historyTs: historyTsForStoring,
+					SIMMissingFromVendorAPI: false,
 				})
 			}
 		} catch {

--- a/lambda/storeSimInformationWirelessLogic.ts
+++ b/lambda/storeSimInformationWirelessLogic.ts
@@ -10,7 +10,10 @@ import { fromEnv } from '@bifravst/from-env'
 import middy from '@middy/core'
 import type { SQSEvent } from 'aws-lambda'
 import { wirelessLogicDataLimit } from './constants.ts'
-import { getSimDetailsFromCache } from './getSimDetailsFromCache.ts'
+import {
+	getSimDetailsFromCache,
+	SIMMissingFromVendorAPI,
+} from './getSimDetailsFromCache.ts'
 import { metricsForComponent } from './metrics.ts'
 import { putSimDetails } from './putSimDetails.ts'
 import { storeHistoricalDataInDB } from './storeHistoricalDataInDB.ts'
@@ -73,11 +76,21 @@ const h = async (event: SQSEvent): Promise<void> => {
 				wirelessLogicDataLimit,
 			})
 			if ('error' in simDetails) {
+				if (simDetails.error instanceof SIMMissingFromVendorAPI) {
+					await putSimDetailsFunc({
+						iccid,
+						simExisting: false,
+						simDetails: undefined,
+						SIMMissingFromVendorAPI: true,
+						ttl: Date.now() / 1000 + 24 * 60 * 60 * 7, // 7 days
+					})
+				}
 				console.error(simDetails.error)
 				await putSimDetailsFunc({
 					iccid,
 					simExisting: false,
 					simDetails: undefined,
+					SIMMissingFromVendorAPI: false,
 				})
 			} else {
 				const simDetailsToDB = {
@@ -88,6 +101,7 @@ const h = async (event: SQSEvent): Promise<void> => {
 					iccid,
 					simExisting: true,
 					simDetails: simDetailsToDB,
+					SIMMissingFromVendorAPI: false,
 				})
 				const diff = (simDetails.value.usedBytes[iccid] ?? 0) - prevUsage
 				if (diff > 0) {

--- a/lambda/wirelessLogic/fetchWirelessLogicSIMDetails.spec.ts
+++ b/lambda/wirelessLogic/fetchWirelessLogicSIMDetails.spec.ts
@@ -7,8 +7,88 @@ import activeSimsTestData2 from './testData/activeSimHistory2.json' assert { typ
 import activeSimsTestData3 from './testData/activeSimHistory3.json' assert { type: 'json' }
 
 void describe('getActiveSimsHistory()', () => {
+	void it('should return an error when SIM is not found in API', async () => {
+		const scope = nock('https://simpro4.wirelesslogic.com')
+		scope
+			.get(
+				'/api/v3/sims/details?identifiers=89444600000000000001%2C89444600000000000002',
+			)
+			.reply(200, [])
+		const iccids = ['89444600000000000001', '89444600000000000002']
+		const activeSims = await fetchWirelessLogicSIMDetails({
+			iccid: iccids,
+			apiKey: 'apiKey',
+			clientId: 'clientId',
+			wirelessLogicDataLimit: 5000000,
+			startDate: new Date('2024-04-03T08:04:14.000Z'),
+		})
+		assert.equal(scope.isDone(), true)
+		assert.equal('error' in activeSims, true)
+		assert.equal(nock.isDone(), true)
+	})
+	void it('should not return an error when at least one SIM is found in API', async () => {
+		const scope = nock('https://simpro4.wirelesslogic.com')
+		scope
+			.get('/api/v3/sims/details?identifiers=89444600000000000002')
+			.reply(200, [
+				{
+					id: 1,
+					iccid: '89444600000000000002',
+				},
+			])
+		scope
+			.get(
+				'/api/v3/sims/usage-history?month=1&identifiers=89444600000000000002',
+			)
+			.reply(200, activeSimsTestData1)
+		scope
+			.get(
+				'/api/v3/sims/usage-history?month=2&identifiers=89444600000000000002',
+			)
+			.reply(200, activeSimsTestData2)
+		scope
+			.get(
+				'/api/v3/sims/usage-history?month=3&identifiers=89444600000000000002',
+			)
+			.reply(200, activeSimsTestData3)
+		scope
+			.get(
+				'/api/v3/sims/usage-history?month=4&identifiers=89444600000000000002',
+			)
+			.reply(200, activeSimsTestData3)
+		const iccids = ['89444600000000000002']
+		const activeSims = await fetchWirelessLogicSIMDetails({
+			iccid: iccids,
+			apiKey: 'apiKey',
+			clientId: 'clientId',
+			wirelessLogicDataLimit: 5000000,
+			startDate: new Date('2024-04-03T08:04:14.000Z'),
+		})
+		assert.equal(scope.isDone(), true)
+		assert.equal('error' in activeSims, false)
+		assert.equal(nock.isDone(), true)
+	})
 	void it('should return the iccids of the active SIMs', async () => {
 		const scope = nock('https://simpro4.wirelesslogic.com')
+		scope
+			.get(
+				'/api/v3/sims/details?identifiers=89444600000000000001%2C89444600000000000002%2C89444600000000000003',
+			)
+			.reply(200, [
+				{
+					id: 0,
+					iccid: '89444600000000000001',
+				},
+				{
+					id: 1,
+					iccid: '89444600000000000002',
+				},
+			])
+		const iccids = [
+			'89444600000000000001',
+			'89444600000000000002',
+			'89444600000000000003',
+		]
 		scope
 			.get(
 				'/api/v3/sims/usage-history?month=1&identifiers=89444600000000000001%2C89444600000000000002',
@@ -29,7 +109,6 @@ void describe('getActiveSimsHistory()', () => {
 				'/api/v3/sims/usage-history?month=4&identifiers=89444600000000000001%2C89444600000000000002',
 			)
 			.reply(200, activeSimsTestData3)
-		const iccids = ['89444600000000000001', '89444600000000000002']
 		const activeSims = await fetchWirelessLogicSIMDetails({
 			iccid: iccids,
 			apiKey: 'apiKey',
@@ -50,6 +129,20 @@ void describe('getActiveSimsHistory()', () => {
 	})
 	void it('should return an error if validation fails', async () => {
 		const scope = nock('https://simpro4.wirelesslogic.com')
+		scope
+			.get(
+				'/api/v3/sims/details?identifiers=89444600000000000001%2C89444600000000000002',
+			)
+			.reply(200, [
+				{
+					id: 0,
+					iccid: '89444600000000000001',
+				},
+				{
+					id: 1,
+					iccid: '89444600000000000002',
+				},
+			])
 		scope
 			.get(
 				'/api/v3/sims/usage-history?month=4&identifiers=89444600000000000001%2C89444600000000000002',

--- a/lambda/wirelessLogic/fetchWirelessLogicSIMDetails.ts
+++ b/lambda/wirelessLogic/fetchWirelessLogicSIMDetails.ts
@@ -1,5 +1,6 @@
 import { Type } from '@sinclair/typebox'
 import { formatTypeBoxErrors } from '../formatTypeBoxErrors.ts'
+import { SIMMissingFromVendorAPI } from '../getSimDetailsFromCache.ts'
 import { validateWithTypeBox } from '../validateWithTypeBox.ts'
 import { getLast4Months } from './getLast4Months.ts'
 
@@ -20,15 +21,31 @@ export const fetchWirelessLogicSIMDetails = async ({
 	clientId: string
 	wirelessLogicDataLimit: number
 	startDate?: Date
-}): Promise<{ value: SimDetailsWL } | { error: Error }> => {
+}): Promise<
+	{ value: SimDetailsWL } | { error: Error | SIMMissingFromVendorAPI }
+> => {
+	//check if SIM in API
 	const wirelessLogicURL = 'https://simpro4.wirelesslogic.com/api/v3/'
+	const simDetails = await fetch(
+		`https://simpro4.wirelesslogic.com/api/v3/sims/details?identifiers=${Array.isArray(iccid) ? iccid.toString() : iccid}`,
+		{
+			headers: { 'x-api-client': clientId, 'x-api-key': apiKey },
+		},
+	)
+	const simDetailsRes = await simDetails.json()
+	if (simDetailsRes.length === 0) {
+		return { error: new SIMMissingFromVendorAPI(iccid.toString()) }
+	}
+	const iccidsInApi = simDetailsRes.map((sim: { iccid: string }) => sim.iccid)
 	const usage: Record<string, number> = {}
 	const months = startDate ? getLast4Months(startDate) : getLast4Months()
 	//api provides history for the last 3 months
 	for (const month of months) {
 		const searchParam = {
 			month: String(month),
-			identifiers: Array.isArray(iccid) ? iccid.toString() : iccid,
+			identifiers: Array.isArray(iccidsInApi)
+				? iccidsInApi.toString()
+				: iccidsInApi,
 		}
 		const url = new URL(
 			`sims/usage-history?${new URLSearchParams(searchParam).toString()}`,


### PR DESCRIPTION
When a user asks for a SIM that is not in vendor API we will cache this information for 30 days. I think this is okay since this is caused by users claiming their SIM and as far as I know their SIM will never get back into our group. 

When asking for the usage for all active SIMs (which we do every 5 minutes for WL) we ignore the SIMs that are not available in the vendors API and we will not continue to ask for usage information about these. 